### PR TITLE
Windows: make sourcemap sources URLs use forward slashs, fix tests

### DIFF
--- a/src/Chain.js
+++ b/src/Chain.js
@@ -2,6 +2,7 @@ import { basename, dirname, extname, relative, resolve } from 'path';
 import { writeFile } from 'sander';
 import SourceMap from './SourceMap';
 import encodeMappings from './utils/encodeMappings';
+import slash from './utils/slash';
 
 let SOURCEMAPPING_URL = 'sourceMa';
 SOURCEMAPPING_URL += 'ppingURL';
@@ -103,7 +104,7 @@ export default class Chain {
 
 		return new SourceMap({
 			file: basename( this.node.file ),
-			sources: allSources.map( source => relative( options.base || dirname( this.node.file ), source ) ),
+			sources: allSources.map( source => slash( relative( options.base || dirname( this.node.file ), source ) ) ),
 			sourcesContent: allSources.map( source => includeContent ? this.sourcesContentByPath[ source ] : null ),
 			names: allNames,
 			mappings

--- a/src/utils/slash.js
+++ b/src/utils/slash.js
@@ -1,0 +1,5 @@
+export default function slash(path) {
+  if (typeof path === 'string')
+    return path.replace(/\\/g, '/');
+  return path;
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -284,7 +284,7 @@ console.log "the answer is #{answer}"'
 				}).then( function () {
 					return sander.readFile( 'tmp/helloworld.min.js' ).then( String ).then( function ( generated ) {
 						var mappingURL = /sourceMappingURL=([^\s]+)/.exec( generated )[1];
-						assert.equal( mappingURL, path.resolve( 'tmp/helloworld.min.js.map' ) );
+						assert.equal( mappingURL, encodeURI( path.resolve( 'tmp/helloworld.min.js.map' ) ) );
 					});
 				});
 			});


### PR DESCRIPTION
@Rich-Harris, this PR makes sourcemap `sources:` URLs use forward slash separators on Windows platforms.

Although not strictly defined in the spec it seems generally accepted that these are URL paths which should use said forward slash.