### PR TITLE
Do not normalize as paths any 'sources' in source .map files that look like URL's

### DIFF
--- a/src/Chain.js
+++ b/src/Chain.js
@@ -106,7 +106,7 @@ export default class Chain {
 
 		return new SourceMap({
 			file: basename( this.node.file ),
-			sources: allSources.map( source => slash( relative( options.base || dirname( this.node.file ), source ) ) ),
+			sources: allSources.map( source => source.indexOf("://") >= 0 ? source : slash( relative( options.base || dirname( this.node.file ), source ) ) ),
 			sourcesContent: allSources.map( source => includeContent ? this.sourcesContentByPath[ source ] : null ),
 			names: allNames,
 			mappings

--- a/src/Node.js
+++ b/src/Node.js
@@ -5,7 +5,7 @@ import getMap from './utils/getMap';
 
 export default class Node {
 	constructor ({ file, content }) {
-		this.file = file ? resolve( file ) : null;
+		this.file = file ? (file.indexOf("://") >= 0 ? file : resolve( file )) : null;
 		this.content = content || null; // sometimes exists in sourcesContent, sometimes doesn't
 
 		if ( !this.file && this.content === null ) {
@@ -77,9 +77,16 @@ export default class Node {
 			sourcesContent = map.sourcesContent || [];
 
 			this.sources = map.sources.map( ( source, i ) => {
+				var resolvedSource = resolveSourcePath(this, map.sourceRoot, source),
+					sourceContent = sourcesContent[i];
+
+				if (!sourcesContentByPath[resolvedSource] && sourceContent) {
+					sourcesContentByPath[resolvedSource] = sourceContent;
+				}
+
 				const node = new Node({
-					file: resolveSourcePath( this, map.sourceRoot, source ),
-					content: sourcesContent[i]
+					file: resolvedSource,
+					content: sourceContent
 				});
 
 				node.loadSync( sourcesContentByPath, sourceMapByPath );
@@ -171,5 +178,5 @@ function getContent ( node, sourcesContentByPath ) {
 }
 
 function resolveSourcePath ( node, sourceRoot, source ) {
-	return resolve( dirname( node.file ), sourceRoot || '', source );
+	return source.indexOf("://") >= 0 ? source :resolve( dirname( node.file ), sourceRoot || '', source );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,13 +24,13 @@ function init ( file, options = {} ) {
 
 	if ( options.content ) {
 		Object.keys( options.content ).forEach( key => {
-			sourcesContentByPath[ key.indexOf("://") >= 0 ? key : resolve( key ) ] = options.content[ key ];
+			sourcesContentByPath[ resolve( key ) ] = options.content[ key ];
 		});
 	}
 
 	if ( options.sourcemaps ) {
 		Object.keys( options.sourcemaps ).forEach( key => {
-			sourceMapByPath[ key.indexOf("://") >= 0 ? key : resolve( key ) ] = options.sourcemaps[ key ];
+			sourceMapByPath[ resolve( key ) ] = options.sourcemaps[ key ];
 		});
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,13 +24,13 @@ function init ( file, options = {} ) {
 
 	if ( options.content ) {
 		Object.keys( options.content ).forEach( key => {
-			sourcesContentByPath[ resolve( key ) ] = options.content[ key ];
+			sourcesContentByPath[ key.indexOf("://") >= 0 ? key : resolve( key ) ] = options.content[ key ];
 		});
 	}
 
 	if ( options.sourcemaps ) {
 		Object.keys( options.sourcemaps ).forEach( key => {
-			sourceMapByPath[ resolve( key ) ] = options.sourcemaps[ key ];
+			sourceMapByPath[ key.indexOf("://") >= 0 ? key : resolve( key ) ] = options.sourcemaps[ key ];
 		});
 	}
 

--- a/test/samples/9/urlSource.js
+++ b/test/samples/9/urlSource.js
@@ -1,0 +1,2 @@
+console.log("url source");
+//# sourceMappingURL=urlSource.js.map

--- a/test/samples/9/urlSource.js.map
+++ b/test/samples/9/urlSource.js.map
@@ -1,0 +1,7 @@
+{
+	"version": 3,
+	"sources":[ "webpack:///./src/bar.js" ],
+	"sourcesContent": [ "console.log('bar');" ],
+	"names": [],
+	"mappings": "AAAA"
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -341,6 +341,21 @@ console.log "the answer is #{answer}"'
 				});
 			});
 		});
+
+		it( 'handles sources with URL patterns differently from file paths (#9)', function () {
+			return sorcery.load( 'samples/9/urlSource.js' ).then( function ( chain ) {
+				return chain.write( '.tmp/write-file/urlSource.js' ).then( function () {
+					return sander.readFile( '.tmp/write-file/urlSource.js.map' )
+						.then( String )
+						.then( function ( js ) {
+							// sources that have "://" in them are not normalized the way filespecs are
+							// and should appear in the target .map file exactly as they appeared in the
+							// source .map file
+							assert.ok( ~js.indexOf( "webpack:///./src/bar.js" ) );
+						});
+				});
+			});
+		});
 	});
 
 	describe( 'sorcery (sync)', function () {


### PR DESCRIPTION
Webpack does something silly with the .map files it writes, where it makes pseudo-URL looking 'sources' paths that don't resolve to files on the local file system.  (Webpack emits paths like "webpack:///./lib/Main.js" instead of "./lib/Main.js" as you would expect.) 

In Sorcery, path.resolve() has at these URL's when the .map is parsed and it normalizes the URL string by stripping out the extra //.  That's fine except it breaks downstream matching for things like 'sourcesContent' in Sorcery's target .map file.  In my case with Webpack, this led to the target 'sources' being full of normalized webpack: URL's and the target 'sourcesContent' being filled with nulls rather than the original sources at those paths that Webpack supplies.

My code change checks to see if any path from 'sources' looks like a URL (contains "://"), and if it does, copies that string verbatim as the file path.  There's probably a cleaner way to do what I am trying to do, I just got sorcery working for me.  I'd be happy to refactor in any way you'd like, thanks!
