### PR TITLE
Allow CLI to recurse over a folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,13 @@ Usage:
   sorcery [options]
 
 Options:
-  -h, --help               Show help message
-  -v, --version            Show version
-  -i, --input <file>       Input file
-  -o, --output <file>      Output file (if absent, will overwrite input)
-  -d, --datauri            Append map as a data URI, rather than separate file
-  -x, --excludeContent     Don't populate the sourcesContent array
+  -h, --help                   Show help message
+  -v, --version                Show version
+  -i, --input <file>           Input file
+  -f, --folder <folder>        Input folder
+  -o, --output <file/folder>   Output file (if absent, will overwrite input) or folder (if -f is used)
+  -d, --datauri                Append map as a data URI, rather than separate file
+  -x, --excludeContent         Don't populate the sourcesContent array
 ```
 
 Examples:
@@ -127,6 +128,12 @@ sorcery -d -i some/generated/code.min.js
 # write to a new file (will create newfile.js and
 # newfile.js.map)
 sorcery -i some/generated/code.min.js -o newfile.js
+
+# use sorcery to recurse over a folder
+sorcery -f some/generated/
+
+# change output folder when recursing over a folder
+sorcery -f some/generated/ -o some/other/generated/
 ```
 
 

--- a/bin/help.md
+++ b/bin/help.md
@@ -5,17 +5,19 @@
     sorcery [options]
 
   Options:
-    -h, --help               Show help message
-    -v, --version            Show version
-    -i, --input <file>       Input file
-    -o, --output <file>      Output file (if absent, will overwrite input)
-    -d, --datauri            Append map as a data URI, rather than separate file
-    -x, --excludeContent     Don't populate the sourcesContent array
+    -h, --help                   Show help message
+    -v, --version                Show version
+    -i, --input <file>           Input file
+    -f, --folder <folder>        Input folder
+    -o, --output <file/folder>   Output file (if absent, will overwrite input) or folder (if -f is used)
+    -d, --datauri                Append map as a data URI, rather than separate file
+    -x, --excludeContent         Don't populate the sourcesContent array
 
 
-  Example:
+  Examples:
 
     sorcery --input some/generated/code.min.js
+    sorcery --glob built/ -o real-built/
 
 
   For more information visit https://github.com/Rich-Harris/sorcery

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var path = require( 'path' );
+var glob = require( 'glob' );
 var minimist = require( 'minimist' );
 var sander = require( 'sander' );
 var showHelp = require( './showHelp' );
@@ -14,7 +15,8 @@ command = minimist( process.argv.slice( 2 ), {
 		v: 'version',
 		h: 'help',
 		d: 'datauri',
-		x: 'excludeContent'
+		x: 'excludeContent',
+        f: 'folder',
 	}
 });
 
@@ -30,17 +32,38 @@ else if ( command.version ) {
 	console.log( 'Sorcery version ' + require( '../package.json' ).version );
 }
 
-else if ( !command.input ) {
-	console.error( 'Error: You must supply an --input (-i) argument. Type sorcery --help for more info' );
+else if ( !command.input && !command.folder ) {
+	console.error( 'Error: You must supply an --input (-i) or --folder (-f) argument. Type sorcery --help for more info' );
+}
+
+else if ( command.folder ) {
+    function globHandler( error, files ) {
+        if ( error ) {
+            console.error( `Error: Failed to glob, ${error}` );
+            return;
+        }
+        files.forEach(function ( file ) {
+            if ( command.output ) {
+                parseFile( file, path.join( command.output, file ) )
+                return;
+            }
+            parseFile( file );
+        });
+    }
+    glob( path.join( command.folder, '/**/*.js' ), globHandler );
 }
 
 else {
-	sander.stat( command.input ).then( function ( stats ) {
+	parseFile( command.input );
+}
+
+function parseFile( inputFile, outputFile ) {
+    sander.stat( inputFile ).then( function ( stats ) {
 		if ( stats.isDirectory() ) {
-			return sander.lsr( command.input ).then( function ( files ) {
+			return sander.lsr( inputFile ).then( function ( files ) {
 				var promises = files.map( function ( file ) {
-					var input = path.join( command.input, file );
-					var output = path.join( command.output || command.input, file );
+					var input = path.join( inputFile, file );
+					var output = path.join( outputFile || command.output || inputFile, file );
 
 					return sorcery.load( input ).then( function ( chain ) {
 						return chain.write( output, {
@@ -54,8 +77,8 @@ else {
 			});
 		}
 
-		return sorcery.load( command.input ).then( function ( chain ) {
-			return chain.write( command.output || command.input, {
+		return sorcery.load( inputFile ).then( function ( chain ) {
+			return chain.write( outputFile || command.output || inputFile, {
 				inline: command.datauri,
 				includeContent: !command.excludeContent
 			});

--- a/bin/index.js
+++ b/bin/index.js
@@ -39,7 +39,7 @@ else if ( !command.input && !command.folder ) {
 else if ( command.folder ) {
     function globHandler( error, files ) {
         if ( error ) {
-            console.error( `Error: Failed to glob, ${error}` );
+            console.error( 'Error: Failed to glob,', error );
             return;
         }
         files.forEach(function ( file ) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "buffer-crc32": "^0.2.5",
+    "glob": "^7.0.0",
     "minimist": "^1.1.0",
     "sander": "^0.4.0",
     "sourcemap-codec": "^1.2.0"


### PR DESCRIPTION
Adds `--folder` flag on the command line.
Re-purposes the `--output` flag when used in conjunction with `--folder`.
Resolves #13.