### PR TITLE
catch when failed to read sources

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -61,7 +61,11 @@ Node.prototype = {
 	loadSync ( sourcesContentByPath, sourceMapByPath ) {
 		if ( !this.content ) {
 			if ( !sourcesContentByPath[ this.file ] ) {
-				sourcesContentByPath[ this.file ] = readFileSync( this.file, { encoding: 'utf-8' });
+				try {
+					sourcesContentByPath[ this.file ] = readFileSync( this.file, { encoding: 'utf-8' });
+				} catch (err) {
+					sourcesContentByPath[ this.file ] = `// error reading file ${this.file}`;
+				}
 			}
 
 			this.content = sourcesContentByPath[ this.file ];
@@ -168,7 +172,8 @@ function getContent ( node, sourcesContentByPath ) {
 	}
 
 	if ( !node.content ) {
-		return readFile( node.file, { encoding: 'utf-8' });
+		return readFile( node.file, { encoding: 'utf-8' })
+			.catch(err => `// error reading file ${node.file}`);
 	}
 
 	return Promise.resolve( node.content );

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,13 @@ describe( 'sorcery', function () {
 			});
 		});
 
+		it( 'do not fail if source could not be loaded', () => {
+			return sorcery.load( 'samples/not-existing/src/helloworld.coffee' ).then( chain => {
+				// we have no source-map
+				assert.equal( chain, null );
+			});
+		});
+
 		it( 'allows user to specify content/sourcemaps', () => {
 			return sorcery.load( 'example.js', {
 				content: {
@@ -324,6 +331,15 @@ console.log "the answer is #{answer}"`
 	});
 
 	describe( 'sorcery (sync)', () => {
+		describe( 'sorcery.loadSync()', () => {
+			it( 'do not fail if source could not be loaded', () => {
+				const chain = sorcery.loadSync( 'samples/not-existing/src/helloworld.coffee' );
+
+				// we have no source-map
+				assert.equal( chain, null );
+			});
+		});
+
 		describe( 'chain.trace()', () => {
 			it( 'follows a mapping back to its origin', () => {
 				const chain = sorcery.loadSync( 'samples/1/tmp/helloworld.min.js' );


### PR DESCRIPTION
If requsted file could not be found in file-system, fallback to comment.
This way the source-map could be created and the user is informed about the problem.

FIXES ISSUE: #142 
