### PR TITLE
Strip bom from sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "rollup-plugin-npm": "^1.4.0",
     "source-map": "^0.5.3",
     "source-map-support": "^0.4.0",
+    "strip-bom": "^3.0.0",
     "uglify-js": "^2.6.2"
   },
   "bin": {

--- a/src/utils/getMapFromUrl.js
+++ b/src/utils/getMapFromUrl.js
@@ -1,5 +1,6 @@
 import { dirname, resolve } from 'path';
 import { readFile, readFileSync, Promise } from 'sander';
+import stripBom from "strip-bom";
 import atob from './atob.js';
 import SOURCEMAPPING_URL from './sourceMappingURL.js';
 
@@ -37,8 +38,8 @@ export default function getMapFromUrl ( url, base, sync ) {
 	url = resolve( dirname( base ), decodeURI( url ) );
 
 	if ( sync ) {
-		return parseJSON( readFileSync( url, { encoding: 'utf-8' }), url );
+		return parseJSON( stripBom( readFileSync( url, { encoding: 'utf-8' }) ), url );
 	} else {
-		return readFile( url, { encoding: 'utf-8' }).then( json => parseJSON( json, url ) );
+		return readFile( url, { encoding: 'utf-8' }).then( json => parseJSON( stripBom( json ), url ) );
 	}
 }

--- a/test/samples/9/datafile.js
+++ b/test/samples/9/datafile.js
@@ -1,0 +1,2 @@
+var datafile = 'some data';
+//# sourceMappingURL=datafile.js.map

--- a/test/samples/9/datafile.js.map
+++ b/test/samples/9/datafile.js.map
@@ -1,0 +1,8 @@
+﻿{
+	"version": 3,
+	"file": "datafile.js",
+	"sources": [ "source.js" ],
+	"sourcesContent": [ null ],
+	"mappings": "AAAA,C",
+	"names": []
+}

--- a/test/samples/9/source.js
+++ b/test/samples/9/source.js
@@ -1,0 +1,1 @@
+var datafile = 'some data';

--- a/test/test.js
+++ b/test/test.js
@@ -82,6 +82,13 @@ console.log "the answer is #{answer}"`
 				chain.apply();
 			});
 		});
+
+		it( 'loads source map files with BOM', () => {
+			return sorcery.load( 'samples/9/datafile.js' ).then( chain => {
+				// // this will throw if 1-length segments are rejected
+				// chain.apply();
+			});
+		});
 	});
 
 	describe( 'chain.trace()', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -84,10 +84,8 @@ console.log "the answer is #{answer}"`
 		});
 
 		it( 'loads source map files with BOM', () => {
-			return sorcery.load( 'samples/9/datafile.js' ).then( chain => {
-				// // this will throw if 1-length segments are rejected
-				// chain.apply();
-			});
+			// this will throw if datafile.js.map has a BOM.
+			return sorcery.load( 'samples/9/datafile.js' );
 		});
 	});
 


### PR DESCRIPTION
Sorcery chokes when it tries to load a source map from file encoded as UTF8 with BOM, because `JSON.parse()` expects '{' to the first character, not the BOM. This commit adds to the load step to strip the BOM from source map files loaded from the file system, before parsing the JSON.


Honestly, I had to wrangle the project a bit just to get it to build, and once I did there were some other test failures that seemed unrelated to my change. I haven't checked any of those changes in.