### PR TITLE
feat: in-memory mode

### DIFF
--- a/src/Chain.js
+++ b/src/Chain.js
@@ -102,9 +102,16 @@ Chain.prototype = {
 
 		let includeContent = options.includeContent !== false;
 
+		let sourceRoot = options.base
+			? resolve( options.base )
+			: this.node.file
+				? dirname( this.node.file )
+				: process.cwd();
+
 		return new SourceMap({
-			file: basename( this.node.file ),
-			sources: allSources.map( source => slash( relative( options.base || dirname( this.node.file ), source ) ) ),
+			file: this.node.file ? basename( this.node.file ) : null,
+			sources: allSources.map( source => slash( relative( sourceRoot, source ) ) ),
+			sourceRoot: slash( sourceRoot ),
 			sourcesContent: allSources.map( source => includeContent ? this.sourcesContentByPath[ source ] : null ),
 			names: allNames,
 			mappings

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -5,6 +5,7 @@ export default function SourceMap ( properties ) {
 
 	this.file           = properties.file;
 	this.sources        = properties.sources;
+	this.sourceRoot     = properties.sourceRoot;
 	this.sourcesContent = properties.sourcesContent;
 	this.names          = properties.names;
 	this.mappings       = properties.mappings;

--- a/src/utils/getMap.js
+++ b/src/utils/getMap.js
@@ -3,7 +3,11 @@ import getMapFromUrl from './getMapFromUrl.js';
 import getSourceMappingUrl from './getSourceMappingUrl.js';
 
 export default function getMap ( node, sourceMapByPath, sync ) {
-	if ( node.file in sourceMapByPath ) {
+	if ( node.map ) {
+		return sync ? node.map : Promise.resolve( node.map );
+	}
+
+	else if ( node.file in sourceMapByPath ) {
 		const map = sourceMapByPath[ node.file ];
 		return sync ? map : Promise.resolve( map );
 	}


### PR DESCRIPTION
This commit makes the default export of `sorcery` a function. You must pass an array whose items must be a string or an object. String items must be the source code of a file with an inline source map. Object items must have a `content` string property, and an optional `map` object property.

The `sorcery` function returns a SourceMap object. Its `file` property must be set before calling `toJSON` if its associated file will be saved somewhere on disk.

You can pass an options object as the second argument, which takes the
same options as `Chain.prototype.apply`.

Other changes made in this commit:
- add `sourceRoot` property to SourceMap
- add `decode` method to Node
- use process.cwd() when `node.file` is null
- check for `node.map` in the getMap function