### PR TITLE
Handle file:// paths to source files

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -1,9 +1,14 @@
 import { dirname, resolve } from 'path';
 import { readFile, readFileSync, Promise } from 'sander';
 import { decode } from 'sourcemap-codec';
+import { parse } from 'url';
 import getMap from './utils/getMap.js';
 
 export default function Node ({ file, content }) {
+	// resolve file:///path to /path
+	if(!!file && file.indexOf("file:") === 0) {
+		file = parse(file)["path"];
+	}
 	this.file = file ? resolve( file ) : null;
 	this.content = content || null; // sometimes exists in sourcesContent, sometimes doesn't
 


### PR DESCRIPTION
Currently if source files are referred to with a `file://` path, `path.resolve` will create an invalid path :
`file:///folder/filename.js` will turn into `/current/directory/file:/folder/filename.js` and then the script cannot load the content.

By using `url.parse`, we'll get the correct path : `/folder/filename.js`