### PR TITLE
Adjust delimiter used to detect the end of source map URLs in JS files.

### DIFF
--- a/src/Chain.js
+++ b/src/Chain.js
@@ -6,7 +6,7 @@ import slash from './utils/slash.js';
 import SOURCEMAPPING_URL from './utils/sourceMappingURL.js';
 
 const SOURCEMAP_COMMENT = new RegExp( `\n*(?:` +
-	`\\/\\/[@#]\\s*${SOURCEMAPPING_URL}=([^'"]+)|` +      // js
+	`\\/\\/[@#]\\s*${SOURCEMAPPING_URL}=([^\n]+)|` +      // js
 	`\\/\\*#?\\s*${SOURCEMAPPING_URL}=([^'"]+)\\s\\*\\/)` + // css
 '\\s*$', 'g' );
 


### PR DESCRIPTION
The current regex will detect a line that starts like a source map URL comment, then capture anything after that line's equal sign, until it encounters a single quote, double quote, or the end of the input.

This will capture too much if the source file contains a line that starts like a source map URL comment, but is not the last line in the file, and no following lines contain a single or double quote.  In such a case, the existing regular expression will continue capturing all subsequent lines, until the end of the input is encountered.  This may include other comments, or even code.

My suggested adjustment should cause the regular expression to detect a line that starts like a source map URL comment, then captures anything after that line's equal sign, up to the end of the line.