### PR TITLE
Fix broken output of sorcery.loadSync()

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -65,6 +65,8 @@ Node.prototype = {
 			}
 
 			this.content = sourcesContentByPath[ this.file ];
+		} else {
+			sourcesContentByPath[ this.file ] = this.content;
 		}
 
 		const map = getMap( this, sourceMapByPath, true );


### PR DESCRIPTION
When using `sorcery.loadSync()` instead of the asynchronous version `sorcery.load()`, the `sourcesContentByPath` map is not populated. The result is that the generated sourcemap's `sourcesContent` array only contains dozens of `null`, so the output isn't usable.