### PR TITLE
Add types folder to package for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	"files": [
 		"src/",
 		"bin/",
+		"types/",
 		"README.md"
 	],
 	"packageManager": "pnpm@9.3.0"


### PR DESCRIPTION
Ensure the types folder is published, so the types export reference can use types: https://github.com/Rich-Harris/sorcery/blob/master/package.json#L10